### PR TITLE
add support for asynchronous tampering

### DIFF
--- a/lib/tamper.js
+++ b/lib/tamper.js
@@ -56,11 +56,14 @@ module.exports = function(accept) {
           else {
             if (Buffer.isBuffer(body)) body = body.toString()
           }
-          body = tamper(body || '', req, this.headers)
-          this.write = original.write
-          this.end = original.end
-          this.setHeader('Content-Length', Buffer.byteLength(body))
-          this.writeHead(this.statusCode, reason)
+		  var outerThis = this;
+          tamper(body || '', req, this.headers, function(updatedBody) {
+			  outerThis.write = original.write
+			  outerThis.end = original.end
+			  outerThis.setHeader('Content-Length', Buffer.byteLength(updatedBody))
+			  outerThis.writeHead(outerThis.statusCode, reason)
+			  outerThis.end(updatedBody)
+		  })
         }
         this.end(body)
       }

--- a/test/test.js
+++ b/test/test.js
@@ -11,8 +11,13 @@ var libpath = process.env.TAMPER_COV ? '../lib-cov' : '../lib'
 var content = 'Content to be replaced'
 
 // Replaces all occurrences of the test-content
-function replace(body) {
-  return body.replace(new RegExp(content, 'g'), 'Replaced content')
+function replace(body, req, headers, finished) {
+  updatedBody = body.replace(new RegExp(content, 'g'), 'Replaced content');
+  if(finished) {
+	finished(updatedBody)
+  } else {
+    return updatedBody
+  }
 }
 
 // A versatile handler to test the various ServerResponse methods


### PR DESCRIPTION
I have a case where tampering with the response body involves making a web service call that returns a promise object. This is my first attempt at adding support for asynchronous tampering, but I'm not sure if it's the right way to do it.
